### PR TITLE
Fix SCSI command on 2.6 kernel PowerPC system.

### DIFF
--- a/linux/device.c
+++ b/linux/device.c
@@ -242,7 +242,14 @@ int32_t GetDeviceType(void* device_ctx)
     }
 
     ret    = 0;
-    chrptr = strchr(dev_path, ':') - 1;
+    chrptr = strchr(dev_path, ':');
+
+    if(!chrptr)
+    {
+        chrptr = strrchr(dev_path, '.');
+    }
+
+    chrptr--;
 
     while(chrptr != dev_path)
     {

--- a/linux/device.c
+++ b/linux/device.c
@@ -247,6 +247,18 @@ int32_t GetDeviceType(void* device_ctx)
     if(!chrptr)
     {
         chrptr = strrchr(dev_path, '.');
+        if(!chrptr)
+        {
+            free((void*)sysfs_path);
+            free((void*)dev_path);
+            free((void*)host_no);
+            free((void*)iscsi_path);
+            free((void*)scsi_path);
+            free((void*)spi_path);
+            free((void*)fc_path);
+            free((void*)sas_path);
+            return dev_type;
+        }
     }
 
     chrptr--;

--- a/worker.c
+++ b/worker.c
@@ -516,9 +516,9 @@ void* WorkingLoop(void* arguments)
 
                     pkt_res_scsi = (AaruPacketResScsi*)out_buf;
                     if(sense_buf) memcpy(out_buf + sizeof(AaruPacketResScsi), sense_buf, sense_len);
-                    if(buffer) memcpy(out_buf + sizeof(AaruPacketResScsi) + sense_len, buffer, pkt_cmd_scsi->buf_len);
+                    if(buffer) memcpy(out_buf + sizeof(AaruPacketResScsi) + sense_len, buffer, le32toh(pkt_cmd_scsi->buf_len));
 
-                    pkt_res_scsi->hdr.len = htole32(sizeof(AaruPacketResScsi) + sense_len + pkt_cmd_scsi->buf_len);
+                    pkt_res_scsi->hdr.len = htole32(sizeof(AaruPacketResScsi) + sense_len + le32toh(pkt_cmd_scsi->buf_len));
                     pkt_res_scsi->hdr.packet_type = AARUREMOTE_PACKET_TYPE_RESPONSE_SCSI;
                     pkt_res_scsi->hdr.version     = AARUREMOTE_PACKET_VERSION;
                     pkt_res_scsi->hdr.remote_id   = htole32(AARUREMOTE_REMOTE_ID);


### PR DESCRIPTION
On my Power Mac G3 running Debian Squeeze, aaruremote would handle client commands such as `device list` fine, but would segfault on any command needing to touch a device, such as `media scan` or `media dump`. This was due to two reasons:

1. When libudev is not in use, `GetDeviceType` assumes that the target of /sys/block/\<dev\>/device contains a colon separator. On my Power Mac, this is not the case with either my internal CD-ROM drive (/dev/hda) or internal hard drive (/dev/hdc). It seems that not all device symlink targets have colons in them, at least not those with corresponding /dev/hd* entries.
2. The handler for `AARUREMOTE_PACKET_TYPE_COMMAND_SCSI` in worker.c was not properly byteswapping `pkt_cmd_scsi->buf_len` in a couple of locations after the call to `SendScsiCommand`, leading the aaru client to hang.

This patchset fixes both issues.