### PR TITLE
Detect SCSI devices on 2.6.26 kernel PowerPC system.

### DIFF
--- a/aaruremote.h
+++ b/aaruremote.h
@@ -548,7 +548,7 @@ void             FreeDeviceInfoList(DeviceInfoList* start);
 uint16_t         DeviceInfoListCount(DeviceInfoList* start);
 void*            DeviceOpen(const char* device_path);
 void             DeviceClose(void* device_ctx);
-int32_t          GetDeviceType(void* device_ctx);
+int32_t          GetDeviceType(const char* device_path);
 int32_t          SendScsiCommand(void*     device_ctx,
                                  char*     cdb,
                                  char*     buffer,

--- a/linux/device.c
+++ b/linux/device.c
@@ -162,6 +162,7 @@ int32_t GetDeviceType(const char* device_path)
     char*       fc_path;
     char*       sas_path;
     int         ret;
+    char        delim;
     char*       chrptr;
     char*       sysfs_path_scr;
     FILE*       file;
@@ -240,23 +241,26 @@ int32_t GetDeviceType(const char* device_path)
     }
 
     ret    = 0;
-    chrptr = strchr(dev_path, ':');
+    delim  = '.';
+    chrptr = strrchr(dev_path, delim);
 
     if(!chrptr)
     {
-        chrptr = strrchr(dev_path, '.');
-        if(!chrptr)
-        {
-            free((void*)sysfs_path);
-            free((void*)dev_path);
-            free((void*)host_no);
-            free((void*)iscsi_path);
-            free((void*)scsi_path);
-            free((void*)spi_path);
-            free((void*)fc_path);
-            free((void*)sas_path);
-            return dev_type;
-        }
+        delim  = ':';
+        chrptr = strrchr(dev_path, delim);
+    }
+
+    if(!chrptr)
+    {
+        free((void*)sysfs_path);
+        free((void*)dev_path);
+        free((void*)host_no);
+        free((void*)iscsi_path);
+        free((void*)scsi_path);
+        free((void*)spi_path);
+        free((void*)fc_path);
+        free((void*)sas_path);
+        return dev_type;
     }
 
     chrptr--;
@@ -268,8 +272,15 @@ int32_t GetDeviceType(const char* device_path)
             chrptr++;
             break;
         }
+        else if(chrptr[0] == delim)
+        {
+            ret = 0;
+        }
+        else
+        {
+            ret++;
+        }
 
-        ret++;
         chrptr--;
     }
 

--- a/linux/device.c
+++ b/linux/device.c
@@ -65,11 +65,9 @@ void DeviceClose(void* device_ctx)
     free(ctx);
 }
 
-int32_t GetDeviceType(void* device_ctx)
+int32_t GetDeviceType(const char* device_path)
 {
-    DeviceContext* ctx = device_ctx;
-
-    if(!ctx) return -1;
+    if(!device_path) return -1;
 
 #ifdef HAS_UDEV
     struct udev*        udev;
@@ -82,7 +80,7 @@ int32_t GetDeviceType(void* device_ctx)
 
     if(!udev) return AARUREMOTE_DEVICE_TYPE_UNKNOWN;
 
-    chrptr = strrchr(ctx->device_path, '/');
+    chrptr = strrchr(device_path, '/');
     if(chrptr == 0) return AARUREMOTE_DEVICE_TYPE_UNKNOWN;
 
     chrptr++;
@@ -169,13 +167,13 @@ int32_t GetDeviceType(void* device_ctx)
     FILE*       file;
     size_t      len = 4096;
 
-    if(strlen(ctx->device_path) <= 5) return dev_type;
+    if(strlen(device_path) <= 5) return dev_type;
 
-    if(strstr(ctx->device_path, "nvme")) return AARUREMOTE_DEVICE_TYPE_NVME;
+    if(strstr(device_path, "nvme")) return AARUREMOTE_DEVICE_TYPE_NVME;
 
-    dev_name = ctx->device_path + 5;
+    dev_name = device_path + 5;
 
-    if(strstr(ctx->device_path, "mmcblk"))
+    if(strstr(device_path, "mmcblk"))
     {
         dev_type = AARUREMOTE_DEVICE_TYPE_MMC;
 

--- a/linux/list_devices.c
+++ b/linux/list_devices.c
@@ -58,7 +58,7 @@ DeviceInfoList* ListDevices()
 
     while(dirent)
     {
-        if(dirent->d_type != DT_REG && dirent->d_type != DT_LNK)
+        if((dirent->d_type != DT_DIR && dirent->d_type != DT_LNK) || dirent->d_name[0] == '.')
         {
             dirent = readdir(dir);
             continue;


### PR DESCRIPTION
On my Power Mac G3 running Debian Lenny (had to downgrade because reasons), aaruremote no longer detected attached ATA or SCSI devices when queried using `aaru device list`. This was due to the following:

1. `GetDeviceType` takes as its sole argument a `void*` which is then cast to a `DeviceContext*`. However, at the only place where this function is called (in the sysfs codepath of `ListDevices`) `GetDeviceType` is passed a `const char*` pointing to the device path. A `DeviceContext` starts with an `int fd` followed by a `char` array, so `GetDeviceType` was always skipping the first four bytes of the device path (at least on 32-bit hosts).
2. /sys/block/\<dev\> are not symlinks in Debian Lenny PowerPC. Rather, they are directories. `ListDevices` would skip entries of /sys/block/ that are not regular files or symlinks.
3. `GetDeviceType` would search from the *start* of a `dev_path` for the `host_no`. On my PowerPC system, `dev_path` is an Open Firmware path, which leads with a PCI bus that follows a similar naming convention as device busses. So, when searching for the '.' or ':' delimiters, `GetDeviceType` would find "pci0000:00" first and would therefore use "pci0000" as the value for `host_no`, which makes no sense when used later in the function.

This patchset fixes the aforementioned issues thusly:

1. Make `GetDeviceType` take and operate on a `const char*` pointing to the device path. Neither the udev nor the sysfs codepaths use any other fields of `DeviceContext` so this change should be safe.
2. Make `ListDevices` care about directories *or* symlinks, but ignore entries starting with a dot (invisibles, ., and ..).
3. Search for `host_no` from the *end* of a `dev_path`, preferring the '.' delimiter for backward compatibility (see d0bbf0dc) then falling back to the more commonly-used ':' delimiter.