### PR TITLE
Detect SCSI devices on 2.6.26 kernel PowerPC system.

### DIFF
--- a/linux/device.c
+++ b/linux/device.c
@@ -164,6 +164,7 @@ int32_t GetDeviceType(void* device_ctx)
     char*       fc_path;
     char*       sas_path;
     int         ret;
+    char        delim;
     char*       chrptr;
     char*       sysfs_path_scr;
     FILE*       file;
@@ -242,23 +243,26 @@ int32_t GetDeviceType(void* device_ctx)
     }
 
     ret    = 0;
-    chrptr = strchr(dev_path, ':');
+    delim  = '.';
+    chrptr = strrchr(dev_path, delim);
 
     if(!chrptr)
     {
-        chrptr = strrchr(dev_path, '.');
-        if(!chrptr)
-        {
-            free((void*)sysfs_path);
-            free((void*)dev_path);
-            free((void*)host_no);
-            free((void*)iscsi_path);
-            free((void*)scsi_path);
-            free((void*)spi_path);
-            free((void*)fc_path);
-            free((void*)sas_path);
-            return dev_type;
-        }
+        delim  = ':';
+        chrptr = strrchr(dev_path, delim);
+    }
+
+    if(!chrptr)
+    {
+        free((void*)sysfs_path);
+        free((void*)dev_path);
+        free((void*)host_no);
+        free((void*)iscsi_path);
+        free((void*)scsi_path);
+        free((void*)spi_path);
+        free((void*)fc_path);
+        free((void*)sas_path);
+        return dev_type;
     }
 
     chrptr--;
@@ -270,8 +274,15 @@ int32_t GetDeviceType(void* device_ctx)
             chrptr++;
             break;
         }
+        else if(chrptr[0] == delim)
+        {
+            ret = 0;
+        }
+        else
+        {
+            ret++;
+        }
 
-        ret++;
         chrptr--;
     }
 

--- a/linux/list_devices.c
+++ b/linux/list_devices.c
@@ -49,6 +49,8 @@ DeviceInfoList* ListDevices()
 
     udev     = udev_new();
     has_udev = udev != 0;
+#else
+    DeviceContext   tmp_ctx;
 #endif
 
     dir = opendir(PATH_SYS_DEVBLOCK);
@@ -137,11 +139,10 @@ DeviceInfoList* ListDevices()
 #else // Use sysfs
         if(!has_udev && !strstr(dirent->d_name, "loop"))
         {
-            tmp_string = malloc(1024);
-            memset((void*)tmp_string, 0, 1024);
-            snprintf((char*)tmp_string, 1024, "/dev/%s", dirent->d_name);
+            memset((void*)tmp_ctx.device_path, 0, 4096);
+            snprintf((char*)tmp_ctx.device_path, 4096, "/dev/%s", dirent->d_name);
 
-            switch(GetDeviceType(tmp_string))
+            switch(GetDeviceType(&tmp_ctx))
             {
                 case AARUREMOTE_DEVICE_TYPE_ATA: strncpy(list_next->this.bus, "ATA", 256); break;
                 case AARUREMOTE_DEVICE_TYPE_ATAPI: strncpy(list_next->this.bus, "ATAPI", 256); break;
@@ -149,6 +150,7 @@ DeviceInfoList* ListDevices()
                 case AARUREMOTE_DEVICE_TYPE_SECURE_DIGITAL: strncpy(list_next->this.bus, "MMC/SD", 256); break;
                 case AARUREMOTE_DEVICE_TYPE_NVME: strncpy(list_next->this.bus, "NVMe", 256); break;
                 case AARUREMOTE_DEVICE_TYPE_SCSI:
+                    tmp_string = malloc(1024);
                     memset((void*)tmp_string, 0, 1024);
                     snprintf((char*)tmp_string, 1024, "%s/%s/device", PATH_SYS_DEVBLOCK, dirent->d_name);
                     line_str = malloc(1024);
@@ -208,11 +210,10 @@ DeviceInfoList* ListDevices()
                         free(line_str);
                     }
 
+                    free((void*)tmp_string);
                     break;
                 default: memset(&list_next->this.bus, 0, 256); break;
             }
-
-            free((void*)tmp_string);
         }
 #endif
 

--- a/linux/list_devices.c
+++ b/linux/list_devices.c
@@ -60,7 +60,7 @@ DeviceInfoList* ListDevices()
 
     while(dirent)
     {
-        if(dirent->d_type != DT_REG && dirent->d_type != DT_LNK)
+        if((dirent->d_type != DT_DIR && dirent->d_type != DT_LNK) || dirent->d_name[0] == '.')
         {
             dirent = readdir(dir);
             continue;


### PR DESCRIPTION
On my Power Mac G3 running Debian Lenny (had to downgrade because reasons), aaruremote no longer detected attached ATA or SCSI devices when queried using `aaru device list`. This was due to the following:

1. `GetDeviceType` takes as its sole argument a `void*` which is then cast to a `DeviceContext*`. However, where this function is called on Linux (in the sysfs codepath of `ListDevices`) `GetDeviceType` is passed a `const char*` pointing to the device path. A `DeviceContext` starts with an `int fd` followed by a `char` array, so `GetDeviceType` was always skipping the first four bytes of the device path (at least on 32-bit hosts).
2. /sys/block/\<dev\> are not symlinks in Debian Lenny PowerPC. Rather, they are directories. `ListDevices` would skip entries of /sys/block/ that are not regular files or symlinks.
3. `GetDeviceType` would search from the *start* of a `dev_path` for the `host_no`. On my PowerPC system, `dev_path` is an Open Firmware path, which leads with a PCI bus that follows a similar naming convention as device busses. So, when searching for the '.' or ':' delimiters, `GetDeviceType` would find "pci0000:00" first and would therefore use "pci0000" as the value for `host_no`, which makes no sense when used later in the function.

This patchset fixes the aforementioned issues thusly:

1. Pass a temporary `DeviceContext` with its `device_path` field containing the device path to `GetDeviceType`. Continue to use `tmp_string` for other temporary paths created within `ListDevices`.
2. Make `ListDevices` care about directories *or* symlinks, but ignore entries starting with a dot (invisibles, ., and ..).
3. Search for `host_no` from the *end* of a `dev_path`, preferring the '.' delimiter for backward compatibility (see d0bbf0dc) then falling back to the more commonly-used ':' delimiter.