### PR TITLE
Fix parsing of /sys/block/XXX/device symlinks.

### DIFF
--- a/linux/device.c
+++ b/linux/device.c
@@ -157,6 +157,7 @@ int32_t GetDeviceType(void* device_ctx)
     const char* dev_name;
     const char* sysfs_path;
     char*       dev_path;
+    char*       dev_path2;
     char*       host_no;
     char*       scsi_path;
     char*       iscsi_path;
@@ -164,7 +165,6 @@ int32_t GetDeviceType(void* device_ctx)
     char*       fc_path;
     char*       sas_path;
     int         ret;
-    char        delim;
     char*       chrptr;
     char*       sysfs_path_scr;
     FILE*       file;
@@ -242,14 +242,21 @@ int32_t GetDeviceType(void* device_ctx)
         return dev_type;
     }
 
-    ret    = 0;
-    delim  = '.';
-    chrptr = strrchr(dev_path, delim);
+    dev_path2 = strrchr(dev_path, '/');
+    if(dev_path2)
+    {
+        ++dev_path2;
+    }
+    else
+    {
+        dev_path2 = dev_path;
+    }
+
+    chrptr = strchr(dev_path2, '.');
 
     if(!chrptr)
     {
-        delim  = ':';
-        chrptr = strrchr(dev_path, delim);
+        chrptr = strchr(dev_path2, ':');
     }
 
     if(!chrptr)
@@ -265,28 +272,7 @@ int32_t GetDeviceType(void* device_ctx)
         return dev_type;
     }
 
-    chrptr--;
-
-    while(chrptr != dev_path)
-    {
-        if(chrptr[0] == '/')
-        {
-            chrptr++;
-            break;
-        }
-        else if(chrptr[0] == delim)
-        {
-            ret = 0;
-        }
-        else
-        {
-            ret++;
-        }
-
-        chrptr--;
-    }
-
-    memcpy((void*)host_no, chrptr, ret);
+    memcpy((void*)host_no, dev_path2, (chrptr - dev_path2));
 
     snprintf(spi_path, len, "/sys/class/spi_host/host%s", host_no);
     snprintf(fc_path, len, "/sys/class/fc_host/host%s", host_no);


### PR DESCRIPTION
As of c810bd8d0739a8c9e17cd8fa5d73b64a2cb491d4, I'm not able to use aaruremote on Linux (5.10). I've tried a few machines and they all have device sylinks like the following example from my CD dumping machine (has a mixture of SATA and IDE drives):

```
/sys/block/sr0/device -> ../../../0:0:0:0
/sys/block/sr1/device -> ../../../0:0:1:0
/sys/block/sr2/device -> ../../../4:0:0:0
/sys/block/sr3/device -> ../../../1:0:0:0
/sys/block/sr4/device -> ../../../3:0:0:0
/sys/block/sr5/device -> ../../../6:0:0:0
```

I'm not sure how many variants of this symlink exist in Linux, but from reading the existing code I *think* the intent was to extract the characters from the start the of last component of the filename up to the delimeter character (`.` or `:`), so I've reworked the code to do that without tripping up on the `..` parts of the path.